### PR TITLE
Pegasus workflow → SwarmAgents job pipeline: profile extractor, per-file data nodes, DTN naming

### DIFF
--- a/docs/PEGASUS_TO_SWARM.md
+++ b/docs/PEGASUS_TO_SWARM.md
@@ -114,6 +114,28 @@ requests (RAM falls back to maxrss; disk from total input bytes; floors set by
 `DataNode` (`swarm/models/data_node.py`) carries the optional `size_bytes`
 field, so converted jobs round-trip cleanly through `Job.from_dict()`.
 
+### DTN naming (`--dtn-map`, `--dtn-names`)
+
+Single-site Pegasus runs record every file at site `local`. Two options control
+the DTN names in the converted jobs:
+
+- `--dtn-map local=dtn1,condorpool=dtn2` — rename Pegasus site names to DTN
+  names one-for-one. Unlisted sites pass through unchanged.
+- `--dtn-names dtn1,dtn2,dtn3` — spread files across the listed DTN pool by a
+  stable hash of the file name: the same file maps to the same DTN in **every**
+  job, giving consistent producer/consumer data locality while exercising
+  multi-DTN selection. Overrides `--dtn-map`.
+
+```bash
+python pegasus_to_swarm_converter.py --input all_runs_jobs_profile.json \
+    --input-type json --output-dir converted_jobs/ \
+    --data-nodes per-file --dtn-names dtn1,dtn2,dtn3
+```
+
+`--generate-agent-configs` collects DTN names from the converted jobs, so the
+generated `agent_profiles.json`/YAML configs automatically list whichever DTNs
+these options produce.
+
 Use `--generate-agent-configs --num-agents N --base-config config_swarm_multi.yml`
 to also emit agent profiles/configs sized to the converted workload (agents get
 every DTN site referenced by the jobs).

--- a/docs/PEGASUS_TO_SWARM.md
+++ b/docs/PEGASUS_TO_SWARM.md
@@ -1,0 +1,161 @@
+# Pegasus → SwarmAgents Job Pipeline
+
+Convert real Pegasus workflow executions into SwarmAgents job JSON files so that
+recorded production workloads (runtimes, resource requests, input/output data)
+can be replayed through the swarm scheduler and compared against the original
+Pegasus execution.
+
+The pipeline has two stages:
+
+```
+ Pegasus submit host                          SwarmAgents host
+┌──────────────────────────────┐             ┌──────────────────────────────────┐
+│ pegasus_profile_extractor.py │  scp JSON   │ pegasus_to_swarm_converter.py    │
+│  *.stampede.db               │ ──────────► │  all_runs_jobs_profile.json      │
+│  workflow.yml / braindump    │             │   → jobs/job_*.json              │
+│  *.cache, rc_meta, *.sub     │             │   → pegasus_baseline.json        │
+└──────────────────────────────┘             │   → conversion_summary.json      │
+                                             └──────────────────────────────────┘
+```
+
+## Stage 1 — Extract job profiles (runs on the Pegasus submit host)
+
+`pegasus_profile_extractor.py` walks one or more Pegasus submit directories
+(each containing a `*.stampede.db` monitord database) and writes
+`all_runs_jobs_profile.json` — a JSON array with one profile dict per job.
+
+```bash
+# Scan a whole tree for every run of every workflow
+python3 pegasus_profile_extractor.py --root /home/ubuntu --output all_runs_jobs_profile.json
+
+# Or target specific runs
+python3 pegasus_profile_extractor.py \
+    --submit-dir /home/ubuntu/drought/ubuntu/pegasus/drought/run0005 \
+    --submit-dir /home/ubuntu/nextgen-workflow/ubuntu/pegasus/nextgen/run0001 \
+    --output profiles.json
+```
+
+Options:
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--root DIR` | — | Recursively discover run dirs (dirs containing `*.stampede.db`). `scratch/` and hidden dirs are pruned; discovery stops descending once a run dir is found. |
+| `--submit-dir DIR` | — | Explicit run dir; repeatable. Can be combined with `--root`. |
+| `--output FILE` | `all_runs_jobs_profile.json` | Output JSON array. |
+| `--job-types LIST` | `compute` | Comma-separated stampede `job.type_desc` values to extract (others: `stage-in-tx`, `stage-out-tx`, `create-dir`, `cleanup`, `registration`). |
+| `--include-failed-runs` | off | Also extract runs whose workflow did not terminate successfully (failed/running runs are skipped by default). |
+
+The script exits non-zero and writes nothing if no profiles were extracted.
+
+### What is extracted, and from where
+
+| Profile field(s) | Source |
+|------------------|--------|
+| `remote_duration_sec_db`, `remote_cpu_time_sec_db`, `maxrss_kb_db`, `exitcode_db`, `transformation_db` | `invocation` table (dagman pre/post scripts excluded), final try |
+| `execution_site_db`, `kickstart_sec_stats` (local duration), retries | `job_instance` table |
+| `submit_timestamp_db`, `queue_time_sec_db` (SUBMIT→EXECUTE) | `jobstate` table |
+| `runtime_{min,max,mean,stddev}_sec_stats`, `runtime_{succeed,failed}_stats`, `try_number_stats` | all tries of the job |
+| `wf_uuid_db`, `dax_label_db`, `wf_status`, `wf_duration_sec` | `workflow` + `workflowstate` tables |
+| `request_cpus_db`, `request_memory_mb_db`, `request_gpus_db` | HTCondor `*.sub` files under the submit dir |
+| `input_files_db`, `output_files_db` (`lfn`, `site`, `size_bytes`) | job→file mapping from the abstract workflow (`workflow.yml` in the run dir, else the `dax:` pointer in `braindump.yml`); sites from the `<label>-0.cache` file; sizes from `rc_meta` |
+| `total_{input,output}_size_bytes_db` | sum of the above file sizes |
+| `network_db.stage_{in,out}` | aggregated `stage-in-tx` / `stage-out-tx` job durations and sites (workflow-level) |
+
+Jobs are matched to their abstract-workflow entry via `invocation.abs_task_id`
+(this handles custom job ids such as `aggregate_H2` and clustered jobs with
+multiple tasks — their file lists are merged), falling back to the
+`_IDnnnnnnn` suffix convention in the executable job name.
+
+### Requirements
+
+Python 3 with PyYAML on the submit host; everything else is stdlib. The
+stampede databases are opened read-only, so extraction is safe to run next to
+live workflows.
+
+## Stage 2 — Convert to SwarmAgents jobs
+
+Copy the JSON to the SwarmAgents host and run the converter:
+
+```bash
+python pegasus_to_swarm_converter.py \
+    --input all_runs_jobs_profile.json --input-type json \
+    --output-dir converted_jobs/ \
+    --data-nodes per-file
+```
+
+This writes:
+
+- `converted_jobs/job_1.json … job_N.json` — SwarmAgents job files (feed to
+  `job_distributor.py` or `run_test.py`)
+- `converted_jobs/pegasus_baseline.json` — per-run Pegasus ground truth
+  (makespans, per-job runtimes, transfer stats) for comparison plots
+- `converted_jobs/conversion_summary.json` — mapping parameters and warnings
+
+Field mapping into each swarm job: `wall_time` ← `remote_duration_sec_db`
+(fallbacks: kickstart, cpu time), `capacities.core/ram/disk/gpu` ← Condor
+requests (RAM falls back to maxrss; disk from total input bytes; floors set by
+`--min-*` flags), `exit_status`/`should_fail` ← exit code.
+
+### `--data-nodes per-file` vs `per-site`
+
+- `per-site` (default, historical behavior): `data_in`/`data_out` are
+  deduplicated to one DataNode per unique site — only the first file name per
+  site survives.
+- `per-file`: every input/output file becomes its own DataNode, preserving the
+  file name and `size_bytes`:
+
+```json
+"data_in": [
+  {"name": "local", "file": "observations.csv", "size_bytes": 7218941},
+  {"name": "local", "file": "region_config.json", "size_bytes": 2834}
+]
+```
+
+`DataNode` (`swarm/models/data_node.py`) carries the optional `size_bytes`
+field, so converted jobs round-trip cleanly through `Job.from_dict()`.
+
+Use `--generate-agent-configs --num-agents N --base-config config_swarm_multi.yml`
+to also emit agent profiles/configs sized to the converted workload (agents get
+every DTN site referenced by the jobs).
+
+## End-to-end example (pegasus2 deployment)
+
+```bash
+# 1. On the Pegasus submit host
+ssh pegasus2
+python3 pegasus_profile_extractor.py --root /home/ubuntu --output all_runs_jobs_profile.json
+exit
+
+# 2. Fetch and convert
+scp pegasus2:~/all_runs_jobs_profile.json .
+python pegasus_to_swarm_converter.py --input all_runs_jobs_profile.json \
+    --input-type json --output-dir converted_jobs/ --data-nodes per-file
+
+# 3. Replay through swarm
+python run_test.py --mode local --agents 20 --topology mesh \
+    --jobs $(ls converted_jobs/job_*.json | wc -l) --db-host localhost \
+    --run-dir runs/pegasus-replay   # point the distributor at converted_jobs/
+```
+
+A July 2026 extraction of the pegasus2 host yielded **25,331 job profiles from
+9 successful runs** (drought, nextgen ×2, quantumchem vqe/shadows ×4,
+s2-segmentation ×2 — s2-segmentation alone contributes 25,157 jobs; filter by
+`run_name` before converting if you want a balanced mix).
+
+## Gotchas
+
+- **Empty `workflow_files`/`rc_pfn` tables**: monitord does not always populate
+  the job→file mapping in the stampede DB — hence the abstract-workflow YAML +
+  cache-file approach.
+- **Missing `workflow.yml` in the run dir** (e.g. quantumchem runs): the
+  extractor follows `braindump.yml`'s `dax:` pointer. Best effort — if the
+  abstract workflow file was edited after the run, the file lists reflect its
+  current contents.
+- **`request_cpus` absent** from many `.sub` files → profile records 0 and the
+  converter substitutes `--default-cores` (1.0).
+- **`kickstart_sec_stats`** is the DAGMan-measured local duration, which
+  includes pegasus-lite overhead (container pulls, staging). It is only a
+  fallback when `remote_duration_sec_db` is missing.
+- **Site names**: single-site runs report everything as `local`; the converter
+  maps sites to DTN names, so multi-site Pegasus runs produce meaningful DTN
+  connectivity constraints.

--- a/pegasus_profile_extractor.py
+++ b/pegasus_profile_extractor.py
@@ -1,0 +1,491 @@
+#!/usr/bin/env python3
+"""
+Pegasus Workflow Job-Profile Extractor
+
+Runs on a Pegasus submit host. Walks one or more Pegasus submit directories
+(each containing a ``*.stampede.db`` monitord database), extracts per-job
+execution profiles, and writes ``all_runs_jobs_profile.json`` — a JSON array
+directly consumable by ``pegasus_to_swarm_converter.py --input-type json``.
+
+Data sources per run directory:
+  - <label>-0.stampede.db  : workflow, job, job_instance, invocation,
+                             jobstate, rc_meta (file sizes)
+  - workflow.yml           : abstract job -> input/output LFN mapping
+  - <label>-0.cache        : LFN -> site mapping (site="..." attributes)
+  - 00/**/<job>.sub        : Condor request_cpus / request_memory / request_gpus
+
+Usage:
+  # Scan a tree for all runs of all workflows
+  python3 pegasus_profile_extractor.py --root /home/ubuntu --output all_runs_jobs_profile.json
+
+  # Or specific submit dirs
+  python3 pegasus_profile_extractor.py \
+      --submit-dir /home/ubuntu/drought/ubuntu/pegasus/drought/run0001 \
+      --submit-dir /home/ubuntu/drought/ubuntu/pegasus/drought/run0002 \
+      --output drought_profiles.json
+
+  # Then convert on the SwarmAgents side:
+  python pegasus_to_swarm_converter.py --input all_runs_jobs_profile.json \
+      --input-type json --output-dir converted_jobs/
+"""
+
+import argparse
+import glob
+import json
+import math
+import os
+import re
+import sqlite3
+import sys
+from typing import Dict, List, Optional, Tuple
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+# Job types from the stampede `job` table considered "real" jobs.
+DEFAULT_JOB_TYPES = ["compute"]
+ABS_ID_RE = re.compile(r"_(ID\d+)$")
+CACHE_SITE_RE = re.compile(r'^(\S+)\s+\S+\s+site="([^"]*)"')
+
+
+# ---------------------------------------------------------------------------
+# Per-run-dir loaders
+# ---------------------------------------------------------------------------
+
+def find_stampede_db(run_dir: str) -> Optional[str]:
+    hits = sorted(glob.glob(os.path.join(run_dir, "*.stampede.db")))
+    return hits[0] if hits else None
+
+
+def _find_abstract_workflow(run_dir: str) -> Optional[str]:
+    """Locate the abstract workflow YAML for a run.
+
+    Prefer workflow.yml inside the submit dir; otherwise follow the ``dax:``
+    pointer in braindump.yml (best effort — the file may have been edited
+    since the run was planned).
+    """
+    path = os.path.join(run_dir, "workflow.yml")
+    if os.path.isfile(path):
+        return path
+    braindump = os.path.join(run_dir, "braindump.yml")
+    if os.path.isfile(braindump):
+        try:
+            with open(braindump) as fh:
+                bd = yaml.safe_load(fh) if yaml else {}
+            dax = (bd or {}).get("dax")
+            if dax and os.path.isfile(dax):
+                return dax
+        except Exception:  # noqa: BLE001
+            pass
+    return None
+
+
+def load_workflow_uses(run_dir: str) -> Dict[str, Dict[str, List[str]]]:
+    """Parse the abstract workflow -> {abs_job_id: {"input": [...], "output": [...]}}."""
+    if yaml is None:
+        return {}
+    path = _find_abstract_workflow(run_dir)
+    if not path:
+        return {}
+    with open(path) as fh:
+        wf = yaml.safe_load(fh)
+    uses_map: Dict[str, Dict[str, List[str]]] = {}
+    for job in wf.get("jobs", []) or []:
+        abs_id = job.get("id")
+        if not abs_id:
+            continue
+        entry = {"input": [], "output": []}
+        for use in job.get("uses", []) or []:
+            ftype = use.get("type")
+            lfn = use.get("lfn")
+            if lfn and ftype in ("input", "output"):
+                entry[ftype].append(lfn)
+        uses_map[abs_id] = entry
+    return uses_map
+
+
+def load_cache_sites(run_dir: str) -> Dict[str, str]:
+    """Parse <label>-0.cache -> {lfn: site}. First site seen per LFN wins."""
+    sites: Dict[str, str] = {}
+    for path in glob.glob(os.path.join(run_dir, "*.cache")):
+        try:
+            with open(path) as fh:
+                for line in fh:
+                    m = CACHE_SITE_RE.match(line.strip())
+                    if m and m.group(1) not in sites:
+                        sites[m.group(1)] = m.group(2)
+        except OSError:
+            continue
+    return sites
+
+
+def load_sub_requests(run_dir: str) -> Dict[str, dict]:
+    """Parse Condor submit files -> {exec_job_id: {cpus, memory_mb, gpus, disk_kb}}."""
+    requests: Dict[str, dict] = {}
+    pattern = re.compile(
+        r"^\s*request_(cpus|memory|gpus|disk)\s*=\s*([0-9.]+)", re.IGNORECASE
+    )
+    for path in glob.glob(os.path.join(run_dir, "**", "*.sub"), recursive=True):
+        exec_job_id = os.path.basename(path)[:-len(".sub")]
+        vals = {}
+        try:
+            with open(path) as fh:
+                for line in fh:
+                    m = pattern.match(line)
+                    if m:
+                        vals[m.group(1).lower()] = float(m.group(2))
+        except OSError:
+            continue
+        if vals:
+            requests[exec_job_id] = vals
+    return requests
+
+
+def load_lfn_sizes(conn: sqlite3.Connection) -> Dict[str, int]:
+    """rc_meta 'size' entries -> {lfn: size_bytes}."""
+    sizes: Dict[str, int] = {}
+    rows = conn.execute(
+        "SELECT l.lfn, m.value FROM rc_meta m "
+        "JOIN rc_lfn l ON m.lfn_id = l.lfn_id WHERE m.\"key\" = 'size'"
+    )
+    for lfn, value in rows:
+        try:
+            sizes[lfn] = int(value)
+        except (TypeError, ValueError):
+            continue
+    return sizes
+
+
+# ---------------------------------------------------------------------------
+# Stat helpers
+# ---------------------------------------------------------------------------
+
+def _stats(values: List[float]) -> dict:
+    if not values:
+        return {"min": None, "max": None, "mean": None, "stddev": None}
+    mean = sum(values) / len(values)
+    var = sum((v - mean) ** 2 for v in values) / len(values)
+    return {
+        "min": min(values),
+        "max": max(values),
+        "mean": round(mean, 4),
+        "stddev": round(math.sqrt(var), 4),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-run extraction
+# ---------------------------------------------------------------------------
+
+def extract_run(run_dir: str, job_types: List[str],
+                default_site: str = "local") -> Tuple[List[dict], dict]:
+    """Extract profiles for one run dir. Returns (profiles, run_summary)."""
+    db_path = find_stampede_db(run_dir)
+    if not db_path:
+        raise FileNotFoundError(f"no *.stampede.db in {run_dir}")
+
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+
+    # --- workflow-level info (root workflow) ---
+    wf_row = conn.execute(
+        "SELECT wf_id, wf_uuid, dax_label FROM workflow "
+        "ORDER BY (parent_wf_id IS NULL) DESC, wf_id LIMIT 1"
+    ).fetchone()
+    if not wf_row:
+        conn.close()
+        raise ValueError(f"empty workflow table in {db_path}")
+    wf_id, wf_uuid, dax_label = wf_row
+
+    ws = conn.execute(
+        "SELECT "
+        " (SELECT MIN(timestamp) FROM workflowstate WHERE wf_id=? AND state='WORKFLOW_STARTED'),"
+        " (SELECT MAX(timestamp) FROM workflowstate WHERE wf_id=? AND state='WORKFLOW_TERMINATED'),"
+        " (SELECT status FROM workflowstate WHERE wf_id=? AND state='WORKFLOW_TERMINATED' "
+        "  ORDER BY timestamp DESC LIMIT 1)",
+        (wf_id, wf_id, wf_id),
+    ).fetchone()
+    wf_start, wf_end, wf_exit = ws
+    wf_duration = (wf_end - wf_start) if (wf_start and wf_end) else None
+    wf_status = ("successful" if wf_exit == 0 else "failed") if wf_exit is not None else "running"
+
+    run_name = f"{dax_label}_{os.path.basename(os.path.normpath(run_dir))}"
+
+    # --- auxiliary per-run maps ---
+    uses_map = load_workflow_uses(run_dir)
+    cache_sites = load_cache_sites(run_dir)
+    sub_requests = load_sub_requests(run_dir)
+    lfn_sizes = load_lfn_sizes(conn)
+
+    def file_entry(lfn: str, fallback_site: str) -> dict:
+        return {
+            "lfn": lfn,
+            "site": cache_sites.get(lfn, fallback_site),
+            "size_bytes": lfn_sizes.get(lfn, 0),
+        }
+
+    # --- network aggregates from stage-in/stage-out transfer jobs ---
+    def transfer_agg(type_desc: str) -> dict:
+        rows = conn.execute(
+            "SELECT ji.site, COALESCE(ji.local_duration, 0) "
+            "FROM job j JOIN job_instance ji ON j.job_id = ji.job_id "
+            "WHERE j.wf_id = ? AND j.type_desc = ?",
+            (wf_id, type_desc),
+        ).fetchall()
+        return {
+            "jobs": len(rows),
+            "transfer_duration_sec": round(sum(r[1] for r in rows), 3),
+            "sites": sorted({r[0] for r in rows if r[0]}),
+        }
+
+    stage_in_agg = transfer_agg("stage-in-tx")
+    stage_out_agg = transfer_agg("stage-out-tx")
+
+    # --- per-job extraction ---
+    placeholders = ",".join("?" * len(job_types))
+    job_rows = conn.execute(
+        f"SELECT job_id, exec_job_id, type_desc FROM job "
+        f"WHERE wf_id = ? AND type_desc IN ({placeholders})",
+        [wf_id] + job_types,
+    ).fetchall()
+
+    profiles: List[dict] = []
+    for job_id, exec_job_id, type_desc in sorted(job_rows, key=lambda r: r[1]):
+        instances = conn.execute(
+            "SELECT job_instance_id, job_submit_seq, site, exitcode, "
+            "COALESCE(local_duration, 0) "
+            "FROM job_instance WHERE job_id = ? ORDER BY job_submit_seq",
+            (job_id,),
+        ).fetchall()
+        if not instances:
+            continue
+        last = instances[-1]
+        ji_id, _, site, exitcode, local_duration = last
+        site = site or default_site
+
+        # Main invocations of the final try (exclude dagman pre/post scripts)
+        inv = conn.execute(
+            "SELECT COALESCE(SUM(remote_duration), 0), SUM(remote_cpu_time), "
+            "MAX(maxrss), MAX(exitcode) "
+            "FROM invocation WHERE job_instance_id = ? "
+            "AND transformation NOT LIKE 'dagman::%'",
+            (ji_id,),
+        ).fetchone()
+        remote_duration, remote_cpu_time, maxrss_kb, inv_exit = inv
+        if exitcode is None:
+            exitcode = inv_exit
+
+        # Queue time: SUBMIT -> EXECUTE of the final try
+        ts = conn.execute(
+            "SELECT "
+            " (SELECT MIN(timestamp) FROM jobstate WHERE job_instance_id=? AND state='SUBMIT'),"
+            " (SELECT MIN(timestamp) FROM jobstate WHERE job_instance_id=? AND state='EXECUTE')",
+            (ji_id, ji_id),
+        ).fetchone()
+        submit_ts, execute_ts = ts
+        queue_time = (execute_ts - submit_ts) if (submit_ts and execute_ts) else None
+
+        # Runtime stats across all tries
+        try_durations = []
+        succeed = failed = 0
+        for inst in instances:
+            d = conn.execute(
+                "SELECT COALESCE(SUM(remote_duration), 0) FROM invocation "
+                "WHERE job_instance_id = ? AND transformation NOT LIKE 'dagman::%'",
+                (inst[0],),
+            ).fetchone()[0]
+            if d:
+                try_durations.append(float(d))
+            if inst[3] == 0:
+                succeed += 1
+            elif inst[3] is not None:
+                failed += 1
+        rt = _stats(try_durations)
+
+        main_tasks = conn.execute(
+            "SELECT transformation, abs_task_id FROM invocation "
+            "WHERE job_instance_id = ? AND abs_task_id IS NOT NULL",
+            (ji_id,),
+        ).fetchall()
+        transformation = main_tasks[0][0] if main_tasks else ""
+
+        # Abstract job id(s) -> input/output files from workflow.yml.
+        # Prefer the DB's abs_task_id (handles custom job ids and clustered
+        # jobs with multiple tasks); fall back to the _IDnnnnnnn suffix
+        # convention in exec_job_id.
+        abs_ids = [t[1] for t in main_tasks if t[1] in uses_map]
+        if not abs_ids:
+            m = ABS_ID_RE.search(exec_job_id)
+            if m and m.group(1) in uses_map:
+                abs_ids = [m.group(1)]
+        uses = {"input": [], "output": []}
+        for aid in abs_ids:
+            for ftype in ("input", "output"):
+                for lfn in uses_map[aid][ftype]:
+                    if lfn not in uses[ftype]:
+                        uses[ftype].append(lfn)
+        input_files = [file_entry(lfn, site) for lfn in uses["input"]]
+        output_files = [file_entry(lfn, site) for lfn in uses["output"]]
+        total_in = sum(f["size_bytes"] for f in input_files)
+        total_out = sum(f["size_bytes"] for f in output_files)
+
+        # Condor resource requests
+        req = sub_requests.get(exec_job_id, {})
+
+        profiles.append({
+            # identity
+            "run_name": run_name,
+            "job_name": exec_job_id,
+            "job_id_db": job_id,
+            "job_type": type_desc,
+            "transformation_db": transformation,
+            # workflow-level
+            "wf_uuid_db": wf_uuid,
+            "dax_label_db": dax_label or "",
+            "wf_status": wf_status,
+            "wf_duration_sec": round(wf_duration, 3) if wf_duration else None,
+            # timing
+            "submit_timestamp_db": submit_ts,
+            "queue_time_sec_db": round(queue_time, 3) if queue_time is not None else None,
+            "remote_duration_sec_db": round(float(remote_duration), 3) if remote_duration else None,
+            "remote_cpu_time_sec_db": (
+                round(float(remote_cpu_time), 3) if remote_cpu_time else None
+            ),
+            "kickstart_sec_stats": round(float(local_duration), 3) if local_duration else None,
+            # resources
+            "request_cpus_db": req.get("cpus", 0),
+            "request_memory_mb_db": req.get("memory", 0),
+            "request_gpus_db": int(req.get("gpus", 0)),
+            "maxrss_kb_db": int(maxrss_kb) if maxrss_kb else 0,
+            # files
+            "input_files_db": input_files,
+            "output_files_db": output_files,
+            "total_input_size_bytes_db": total_in,
+            "total_output_size_bytes_db": total_out,
+            # outcome
+            "exitcode_db": int(exitcode) if exitcode is not None else 0,
+            "execution_site_db": site,
+            # retries / stats
+            "try_number_stats": len(instances),
+            "runtime_min_sec_stats": rt["min"],
+            "runtime_max_sec_stats": rt["max"],
+            "runtime_mean_sec_stats": rt["mean"],
+            "runtime_stddev_sec_stats": rt["stddev"],
+            "runtime_succeed_stats": succeed,
+            "runtime_failed_stats": failed,
+            # network (workflow-level transfer aggregates, duplicated per job)
+            "network_db": {
+                "stage_in": {
+                    "bytes_transferred": total_in,
+                    "transfer_duration_sec": stage_in_agg["transfer_duration_sec"],
+                    "sites": stage_in_agg["sites"],
+                },
+                "stage_out": {
+                    "bytes_transferred": total_out,
+                    "transfer_duration_sec": stage_out_agg["transfer_duration_sec"],
+                    "sites": stage_out_agg["sites"],
+                },
+            },
+        })
+
+    conn.close()
+
+    summary = {
+        "run_dir": run_dir,
+        "run_name": run_name,
+        "wf_uuid": wf_uuid,
+        "wf_status": wf_status,
+        "makespan_sec": round(wf_duration, 3) if wf_duration else None,
+        "jobs_extracted": len(profiles),
+    }
+    return profiles, summary
+
+
+# ---------------------------------------------------------------------------
+# Run-dir discovery
+# ---------------------------------------------------------------------------
+
+def discover_run_dirs(root: str) -> List[str]:
+    """Find all dirs under root that contain a *.stampede.db file."""
+    run_dirs = set()
+    for dirpath, dirnames, filenames in os.walk(root):
+        # skip scratch/staging trees and hidden dirs
+        dirnames[:] = [d for d in dirnames if not d.startswith(".") and d != "scratch"]
+        if any(f.endswith(".stampede.db") and not f.startswith("._") for f in filenames):
+            run_dirs.add(dirpath)
+            dirnames[:] = []  # don't descend into a run dir
+    return sorted(run_dirs)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Extract Pegasus job profiles into the JSON format consumed "
+                    "by pegasus_to_swarm_converter.py (--input-type json)."
+    )
+    parser.add_argument("--root", help="Directory tree to scan for *.stampede.db run dirs.")
+    parser.add_argument("--submit-dir", action="append", default=[],
+                        help="Specific Pegasus submit (run) directory. Repeatable.")
+    parser.add_argument("--output", default="all_runs_jobs_profile.json",
+                        help="Output JSON file. Default: all_runs_jobs_profile.json")
+    parser.add_argument("--job-types", default=",".join(DEFAULT_JOB_TYPES),
+                        help="Comma-separated stampede job type_desc values to extract. "
+                             "Default: compute. (Others: stage-in-tx, stage-out-tx, "
+                             "create-dir, cleanup, registration)")
+    parser.add_argument("--include-failed-runs", action="store_true",
+                        help="Include runs whose workflow did not finish successfully.")
+    args = parser.parse_args()
+
+    run_dirs = list(args.submit_dir)
+    if args.root:
+        run_dirs.extend(discover_run_dirs(args.root))
+    run_dirs = sorted(set(run_dirs))
+    if not run_dirs:
+        print("No run directories found. Use --root or --submit-dir.", file=sys.stderr)
+        return 1
+
+    job_types = [t.strip() for t in args.job_types.split(",") if t.strip()]
+
+    all_profiles: List[dict] = []
+    summaries: List[dict] = []
+    skipped: List[str] = []
+
+    for rd in run_dirs:
+        try:
+            profiles, summary = extract_run(rd, job_types)
+        except Exception as exc:  # noqa: BLE001 — report and continue
+            print(f"WARN: skipping {rd}: {exc}", file=sys.stderr)
+            skipped.append(rd)
+            continue
+        if summary["wf_status"] != "successful" and not args.include_failed_runs:
+            print(f"SKIP (wf_status={summary['wf_status']}): {rd}", file=sys.stderr)
+            skipped.append(rd)
+            continue
+        all_profiles.extend(profiles)
+        summaries.append(summary)
+        print(f"  {summary['run_name']:45s} jobs={summary['jobs_extracted']:4d} "
+              f"status={summary['wf_status']} makespan={summary['makespan_sec']}s")
+
+    if not all_profiles:
+        print(f"ERROR: no job profiles extracted from {len(run_dirs)} run dir(s) "
+              f"({len(skipped)} skipped). Nothing written. "
+              "Use --include-failed-runs to include unsuccessful runs.",
+              file=sys.stderr)
+        return 1
+
+    with open(args.output, "w") as fh:
+        json.dump(all_profiles, fh, indent=2)
+
+    print(f"\nExtracted {len(all_profiles)} job profiles from "
+          f"{len(summaries)} runs ({len(skipped)} skipped) -> {args.output}")
+    print("Next: python pegasus_to_swarm_converter.py "
+          f"--input {args.output} --input-type json --output-dir converted_jobs/")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pegasus_to_swarm_converter.py
+++ b/pegasus_to_swarm_converter.py
@@ -163,14 +163,30 @@ def _map_capacities(profile: dict, default_cores: float, min_ram_gb: float,
     }
 
 
-def _map_data_nodes(files_list: Optional[list]) -> Optional[list]:
+def _map_data_nodes(files_list: Optional[list],
+                    mode: str = "per-site") -> Optional[list]:
     """Map Pegasus input/output file lists to SwarmAgents DataNode dicts.
 
-    Per-job dedup: one DataNode per unique non-empty site name.
-    Files with empty site are skipped.
+    mode="per-site": one DataNode per unique non-empty site name (first lfn
+    seen wins) — the historical behavior.
+    mode="per-file": one DataNode per file, preserving every lfn (and its
+    size_bytes when present).
+    Files with empty site are skipped in both modes.
     """
     if not files_list:
         return None
+
+    if mode == "per-file":
+        nodes = []
+        for f in files_list:
+            site = (f.get("site") or "").strip()
+            if not site:
+                continue
+            node = {"name": site, "file": f.get("lfn", "")}
+            if f.get("size_bytes") is not None:
+                node["size_bytes"] = f["size_bytes"]
+            nodes.append(node)
+        return nodes or None
 
     seen_sites: Dict[str, str] = {}  # site -> first lfn
     for f in files_list:
@@ -194,7 +210,8 @@ def map_profile(profile: dict, job_number: int,
                 min_wall_time: float = 0.1,
                 default_cores: float = 1.0,
                 min_ram_gb: float = 0.1,
-                min_disk_gb: float = 1.0) -> Tuple[dict, List[str]]:
+                min_disk_gb: float = 1.0,
+                data_nodes_mode: str = "per-site") -> Tuple[dict, List[str]]:
     """Convert a single Pegasus profile to a SwarmAgents job dict."""
     warnings: List[str] = []
 
@@ -208,8 +225,8 @@ def map_profile(profile: dict, job_number: int,
 
     capacities = _map_capacities(profile, default_cores, min_ram_gb, min_disk_gb)
 
-    data_in = _map_data_nodes(profile.get("input_files_db"))
-    data_out = _map_data_nodes(profile.get("output_files_db"))
+    data_in = _map_data_nodes(profile.get("input_files_db"), data_nodes_mode)
+    data_out = _map_data_nodes(profile.get("output_files_db"), data_nodes_mode)
 
     exitcode = int(profile.get("exitcode_db", 0) or 0)
     should_fail = exitcode != 0
@@ -501,6 +518,7 @@ def convert_pegasus_profiles(
     default_cores: float = 1.0,
     min_ram_gb: float = 0.1,
     min_disk_gb: float = 1.0,
+    data_nodes_mode: str = "per-site",
 ) -> dict:
     """Convert Pegasus profiles to SwarmAgents job JSON files.
 
@@ -561,6 +579,7 @@ def convert_pegasus_profiles(
             default_cores=default_cores,
             min_ram_gb=min_ram_gb,
             min_disk_gb=min_disk_gb,
+            data_nodes_mode=data_nodes_mode,
         )
 
         # Write job file
@@ -658,6 +677,7 @@ def convert(args: argparse.Namespace):
             default_cores=args.default_cores,
             min_ram_gb=args.min_ram_gb,
             min_disk_gb=args.min_disk_gb,
+            data_nodes_mode=args.data_nodes,
         )
 
         # Write job file
@@ -787,6 +807,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--default-cores", type=float, default=1.0,
         help="Default core count when request_cpus_db is 0. Default: 1.0."
+    )
+    parser.add_argument(
+        "--data-nodes", choices=["per-site", "per-file"], default="per-site",
+        help="data_in/data_out granularity: 'per-site' dedups to one DataNode "
+             "per site (historical behavior); 'per-file' keeps every "
+             "input/output file with its size. Default: per-site."
     )
 
     # Agent config generation

--- a/pegasus_to_swarm_converter.py
+++ b/pegasus_to_swarm_converter.py
@@ -163,18 +163,45 @@ def _map_capacities(profile: dict, default_cores: float, min_ram_gb: float,
     }
 
 
+def make_dtn_resolver(dtn_map: Optional[Dict[str, str]] = None,
+                      dtn_names: Optional[List[str]] = None):
+    """Build a (site, lfn) -> DTN-name resolver.
+
+    dtn_map renames Pegasus site names (e.g. {"local": "dtn1"}); sites not in
+    the map pass through unchanged. dtn_names, if given, instead spreads files
+    across the listed DTNs by a stable hash of the lfn, so the same file maps
+    to the same DTN in every job (consistent data locality). dtn_names wins
+    over dtn_map when both are provided.
+    """
+    import hashlib
+
+    def resolve(site: str, lfn: str) -> str:
+        if dtn_names:
+            idx = int(hashlib.md5(lfn.encode()).hexdigest(), 16) % len(dtn_names)
+            return dtn_names[idx]
+        if dtn_map:
+            return dtn_map.get(site, site)
+        return site
+
+    return resolve
+
+
 def _map_data_nodes(files_list: Optional[list],
-                    mode: str = "per-site") -> Optional[list]:
+                    mode: str = "per-site",
+                    resolve=None) -> Optional[list]:
     """Map Pegasus input/output file lists to SwarmAgents DataNode dicts.
 
-    mode="per-site": one DataNode per unique non-empty site name (first lfn
+    mode="per-site": one DataNode per unique non-empty DTN name (first lfn
     seen wins) — the historical behavior.
     mode="per-file": one DataNode per file, preserving every lfn (and its
     size_bytes when present).
-    Files with empty site are skipped in both modes.
+    Files with empty site are skipped in both modes. *resolve* (see
+    make_dtn_resolver) turns a Pegasus site + lfn into a DTN name.
     """
     if not files_list:
         return None
+    if resolve is None:
+        resolve = lambda site, lfn: site  # noqa: E731
 
     if mode == "per-file":
         nodes = []
@@ -182,24 +209,27 @@ def _map_data_nodes(files_list: Optional[list],
             site = (f.get("site") or "").strip()
             if not site:
                 continue
-            node = {"name": site, "file": f.get("lfn", "")}
+            lfn = f.get("lfn", "")
+            node = {"name": resolve(site, lfn), "file": lfn}
             if f.get("size_bytes") is not None:
                 node["size_bytes"] = f["size_bytes"]
             nodes.append(node)
         return nodes or None
 
-    seen_sites: Dict[str, str] = {}  # site -> first lfn
+    seen_sites: Dict[str, str] = {}  # dtn name -> first lfn
     for f in files_list:
         site = (f.get("site") or "").strip()
         if not site:
             continue
-        if site not in seen_sites:
-            seen_sites[site] = f.get("lfn", "")
+        lfn = f.get("lfn", "")
+        name = resolve(site, lfn)
+        if name not in seen_sites:
+            seen_sites[name] = lfn
 
     if not seen_sites:
         return None
 
-    return [{"name": site, "file": lfn} for site, lfn in seen_sites.items()]
+    return [{"name": name, "file": lfn} for name, lfn in seen_sites.items()]
 
 
 # ---------------------------------------------------------------------------
@@ -211,7 +241,8 @@ def map_profile(profile: dict, job_number: int,
                 default_cores: float = 1.0,
                 min_ram_gb: float = 0.1,
                 min_disk_gb: float = 1.0,
-                data_nodes_mode: str = "per-site") -> Tuple[dict, List[str]]:
+                data_nodes_mode: str = "per-site",
+                dtn_resolver=None) -> Tuple[dict, List[str]]:
     """Convert a single Pegasus profile to a SwarmAgents job dict."""
     warnings: List[str] = []
 
@@ -225,8 +256,10 @@ def map_profile(profile: dict, job_number: int,
 
     capacities = _map_capacities(profile, default_cores, min_ram_gb, min_disk_gb)
 
-    data_in = _map_data_nodes(profile.get("input_files_db"), data_nodes_mode)
-    data_out = _map_data_nodes(profile.get("output_files_db"), data_nodes_mode)
+    data_in = _map_data_nodes(profile.get("input_files_db"), data_nodes_mode,
+                              dtn_resolver)
+    data_out = _map_data_nodes(profile.get("output_files_db"), data_nodes_mode,
+                               dtn_resolver)
 
     exitcode = int(profile.get("exitcode_db", 0) or 0)
     should_fail = exitcode != 0
@@ -519,6 +552,8 @@ def convert_pegasus_profiles(
     min_ram_gb: float = 0.1,
     min_disk_gb: float = 1.0,
     data_nodes_mode: str = "per-site",
+    dtn_map: Optional[Dict[str, str]] = None,
+    dtn_names: Optional[List[str]] = None,
 ) -> dict:
     """Convert Pegasus profiles to SwarmAgents job JSON files.
 
@@ -566,6 +601,7 @@ def convert_pegasus_profiles(
 
     os.makedirs(output_dir, exist_ok=True)
 
+    dtn_resolver = make_dtn_resolver(dtn_map, dtn_names)
     baseline = BaselineBuilder()
     all_warnings: List[dict] = []
     sites_seen: Dict[str, int] = {}
@@ -580,6 +616,7 @@ def convert_pegasus_profiles(
             min_ram_gb=min_ram_gb,
             min_disk_gb=min_disk_gb,
             data_nodes_mode=data_nodes_mode,
+            dtn_resolver=dtn_resolver,
         )
 
         # Write job file
@@ -664,6 +701,14 @@ def convert(args: argparse.Namespace):
 
     os.makedirs(args.output_dir, exist_ok=True)
 
+    dtn_map = None
+    if args.dtn_map:
+        dtn_map = dict(pair.split("=", 1) for pair in args.dtn_map.split(","))
+    dtn_names = None
+    if args.dtn_names:
+        dtn_names = [n.strip() for n in args.dtn_names.split(",") if n.strip()]
+    dtn_resolver = make_dtn_resolver(dtn_map, dtn_names)
+
     baseline = BaselineBuilder()
     all_warnings: List[dict] = []
     sites_seen: Dict[str, int] = {}
@@ -678,6 +723,7 @@ def convert(args: argparse.Namespace):
             min_ram_gb=args.min_ram_gb,
             min_disk_gb=args.min_disk_gb,
             data_nodes_mode=args.data_nodes,
+            dtn_resolver=dtn_resolver,
         )
 
         # Write job file
@@ -813,6 +859,17 @@ def parse_args() -> argparse.Namespace:
         help="data_in/data_out granularity: 'per-site' dedups to one DataNode "
              "per site (historical behavior); 'per-file' keeps every "
              "input/output file with its size. Default: per-site."
+    )
+    parser.add_argument(
+        "--dtn-map", type=str, default=None,
+        help="Rename Pegasus sites to DTN names, e.g. 'local=dtn1,condorpool=dtn2'. "
+             "Unlisted sites pass through unchanged."
+    )
+    parser.add_argument(
+        "--dtn-names", type=str, default=None,
+        help="Comma-separated DTN pool, e.g. 'dtn1,dtn2,dtn3'. Files are spread "
+             "across the pool by a stable hash of the file name (same file -> "
+             "same DTN in every job). Overrides --dtn-map."
     )
 
     # Agent config generation

--- a/swarm/models/data_node.py
+++ b/swarm/models/data_node.py
@@ -36,6 +36,7 @@ class DataNode(JSONField):
         self._ip = None
         self._user = None
         self._connectivity_score = 0.0
+        self._size_bytes = None
         self._set_fields(**kwargs)
 
     @property
@@ -77,6 +78,14 @@ class DataNode(JSONField):
     @connectivity_score.setter
     def connectivity_score(self, connectivity_score: float):
         self._connectivity_score = connectivity_score
+
+    @property
+    def size_bytes(self):
+        return self._size_bytes
+
+    @size_bytes.setter
+    def size_bytes(self, size_bytes: int):
+        self._size_bytes = size_bytes
 
     def _set_fields(self, forgiving=False, **kwargs):
         """


### PR DESCRIPTION
## Summary

Adds an end-to-end pipeline for replaying real Pegasus workflow executions through the swarm scheduler.

### New: `pegasus_profile_extractor.py`
Runs on the Pegasus submit host. Walks run dirs (`*.stampede.db`) and emits `all_runs_jobs_profile.json`, directly consumable by `pegasus_to_swarm_converter.py --input-type json`. Per job it extracts:
- runtimes, CPU time, exit codes, queue times (SUBMIT→EXECUTE), retries, per-try runtime stats — from the stampede DB
- `request_cpus/memory/gpus` from HTCondor `.sub` files; `maxrss` from kickstart records
- input/output files (`lfn`, `site`, `size_bytes`) — job→file mapping from the abstract workflow (`workflow.yml`, falling back to the `dax:` pointer in `braindump.yml`), sites from the planner cache file, sizes from `rc_meta`
- workflow-level makespan/status and stage-in/out transfer aggregates

Jobs are matched via `invocation.abs_task_id` (handles custom job ids and clustered jobs), with the `_IDnnnnnnn` suffix as fallback. Failed/running runs are skipped by default (`--include-failed-runs` to override); exits non-zero if nothing was extracted.

### Converter: `pegasus_to_swarm_converter.py`
- `--data-nodes per-file|per-site` — `per-file` preserves every input/output file (with `size_bytes`) as a DataNode; default `per-site` keeps the historical one-node-per-site dedup
- `--dtn-map local=dtn1,...` — rename Pegasus sites to DTN names
- `--dtn-names dtn1,dtn2,dtn3` — spread files across a DTN pool via a stable per-lfn hash (same file → same DTN in every job, giving consistent producer/consumer locality)

### Model: `swarm/models/data_node.py`
- optional `size_bytes` field on `DataNode` (round-trips through `Job.from_dict()`)

### Docs
- `docs/PEGASUS_TO_SWARM.md` — pipeline usage, field-mapping table, DTN naming options, end-to-end example, gotchas

## Validation
- Extracted **25,331 job profiles from 9 successful runs** on the pegasus2 host (drought, nextgen ×2, quantumchem vqe/shadows ×4, s2-segmentation ×2); all converted with 0 warnings
- Local replay of the 174 non-s2 jobs (`run_test.py --pegasus-profiles ... --pegasus-input-type json`, 10 agents, mesh): 174/174 complete, 0 failed, mean scheduling latency 0.52 s vs 18.9 s mean HTCondor queue time in the original runs
- `--dtn-names` verified consistent: every file maps to the same DTN across all jobs
- Unit tests pass (the `test_bandit.py` step-size failure seen locally is pre-existing seed-dependent flakiness)