### PR TITLE
feat(agents): first-class failed-agent rejoin protocol (ROADMAP item 14)

### DIFF
--- a/config_swarm_multi.yml
+++ b/config_swarm_multi.yml
@@ -57,6 +57,8 @@ runtime:
   job_reassignment_enabled: true       # Enable automatic job reassignment
   aggressive_failure_detection: true # Use proactive failure detection from gRPC
   enable_agent_recovery: true        # Allow recovered agents to rejoin the pool
+  recovery_grace_seconds: 10         # Heartbeat must stay fresh this long before a failed agent rejoins
+  recovery_cooldown_seconds: 15      # After rejoin, channel-DOWN events can't re-fail the agent (reconnect settling)
   max_infeasible_retries: 10         # Retire infeasible jobs after N attempts (0 = infinite)
   max_delegation_attempts: 3         # Mark job infeasible after N failed delegation timeouts
   #neighbor_refresh_full_s: 5        # Full Redis neighbor-refresh cadence. Default: per-tick

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -124,10 +124,10 @@ When evaluating peer parent agents in hierarchical topology, feasibility uses ag
 
 **Recommendation:** Consider adding a "delegation confidence" score or a pre-delegation feasibility query to children.
 
-### 14. Agent Recovery
-Failed agents are detected and removed but have no first-class rejoin protocol. Partially addressed: SWIM membership tracks rejoining peers, and the contextual-bandit layer re-adopts recovered delegation targets (Scenario C: liveness gate + decayed timeout signal).
+### 14. Agent Recovery — DONE
+Implemented via `RecoveryTracker` (`swarm/utils/recovery.py`) + wiring in `resource_agent.py`. Three rejoin signals: heartbeat progress (record written *after* the failure timestamp, fresh for `recovery_grace_seconds`), gRPC channel-up, and SWIM alive/joined — all funnel through `_on_agent_recovered`, and the agent re-enters neighbor maps/quorum via the normal refresh path. A `recovery_cooldown_seconds` window keeps stale channel-DOWN events from flapping a just-recovered agent while its reconnect settles. Unit tests in `tests/test_agent_recovery.py`; validated end-to-end (SIGKILL → detect 1s → 0 spurious recoveries while dead → rejoin ~7s after restart, one clean recovery per peer).
 
-**Recommendation:** Complete the rejoin protocol at the agent layer: re-announce via heartbeat, re-enter neighbor maps, re-add to quorum (`enable_agent_recovery` TODO in `resource_agent.py`).
+Remaining nuance: recovery trusts the restarted process; there is no state resync for jobs the agent held pre-crash (they are reassigned by the failure path).
 
 ---
 

--- a/swarm/agents/resource_agent.py
+++ b/swarm/agents/resource_agent.py
@@ -46,6 +46,7 @@ from swarm.selection.engine import SelectionEngine
 from swarm.selection.penalties import apply_multiplicative_penalty
 from swarm.topology.topology import TopologyType
 from swarm.utils.metrics import Metrics
+from swarm.utils.recovery import RecoveryTracker
 from swarm.utils.resource_queues import ResourceAgentQueues
 from swarm.utils.thread_safe_dict import ThreadSafeDict
 from swarm.agents.agent_grpc import Agent
@@ -243,10 +244,13 @@ class _SwimAdapter:
         self.agent.logger.warning(msg)
 
     def on_agent_alive(self, agent_id: int) -> None:
-        pass  # advisory in Phase 1
+        # SWIM got an ack from the agent — direct recovery evidence for a
+        # previously failed peer (no-op for healthy peers).
+        self.agent.on_swim_member_alive(agent_id)
 
     def on_agent_joined(self, agent_id: int) -> None:
         self.agent.logger.info(f"[SWIM] joined: {agent_id}")
+        self.agent.on_swim_member_alive(agent_id)
 
     def on_agent_suspected(self, agent_id: int) -> None:
         self.agent.logger.info(f"[SWIM] suspected: {agent_id}")
@@ -413,6 +417,19 @@ class ResourceAgent(Agent):
 
         # Track failed agents and job assignments
         self.failed_agents = ThreadSafeDict[int, float]()  # agent_id -> failure_timestamp
+        # Rejoin decisions for failed agents (ROADMAP item 14): passive
+        # heartbeat recovery needs a grace window; direct evidence (channel
+        # up, SWIM ack) promotes immediately. The tracker is the only thing
+        # that removes entries from failed_agents.
+        self.recovery = RecoveryTracker(
+            self.failed_agents,
+            grace_seconds=self.recovery_grace_seconds,
+        )
+        # agent_id -> last recovery ts; used to keep the aggressive (channel-
+        # DOWN) path from re-failing a just-recovered agent while its channel
+        # reconnect is still in flight. Heartbeat-staleness detection is not
+        # suppressed, so a truly dead agent is still re-failed promptly.
+        self._recovered_at = ThreadSafeDict[int, float]()
         self.job_assignments = ThreadSafeDict[str, int]()  # job_id -> assigned_agent_id
 
         # Consensus messages that arrived before their job (see _HostAdapter.set_pending_*).
@@ -698,8 +715,18 @@ class ResourceAgent(Agent):
 
     @property
     def enable_agent_recovery(self) -> bool:
-        """Allow recovered agents to rejoin the pool when their gRPC channel comes back UP."""
+        """Allow recovered agents to rejoin the pool (heartbeat, channel-up, or SWIM evidence)."""
         return self.runtime_config.get("enable_agent_recovery", True)
+
+    @property
+    def recovery_grace_seconds(self) -> float:
+        """How long a failed agent's heartbeat must stay fresh before it may rejoin."""
+        return float(self.runtime_config.get("recovery_grace_seconds", 10.0))
+
+    @property
+    def recovery_cooldown_seconds(self) -> float:
+        """After a rejoin, channel-DOWN events can't re-fail the agent for this long."""
+        return float(self.runtime_config.get("recovery_cooldown_seconds", 15.0))
 
     def __on_proposal(self, incoming: Proposal):
         self.engine.on_proposal(incoming)
@@ -1242,13 +1269,23 @@ class ResourceAgent(Agent):
             for agent_data in agent_dicts:
                 agent = AgentInfo.from_dict(agent_data)
 
-                # Skip agents that have been marked as failed
+                # Failed agents stay excluded until the recovery tracker
+                # promotes them: their heartbeat must stay fresh for the full
+                # grace window (or direct channel-up/SWIM evidence arrives).
                 if agent.agent_id in self.failed_agents:
-                    self.logger.debug(
-                        f"Skipping failed agent {agent.agent_id} during neighbor refresh "
-                        f"(failed at {self.failed_agents.get(agent.agent_id)})"
-                    )
-                    continue
+                    fresh = (current_time - agent.last_updated) <= self.failure_threshold_seconds
+                    if self.enable_agent_recovery and self.recovery.observe(
+                            agent.agent_id, last_updated=agent.last_updated,
+                            fresh=fresh, now=current_time):
+                        self._on_agent_recovered(agent.agent_id, source="heartbeat")
+                        # fall through: re-add to the map below
+                    else:
+                        self.logger.debug(
+                            f"Skipping failed agent {agent.agent_id} during neighbor refresh "
+                            f"(failed at {self.failed_agents.get(agent.agent_id)}, "
+                            f"fresh={fresh}, recovering_since={self.recovery.recovering_since(agent.agent_id)})"
+                        )
+                        continue
 
                 # Skip agents that are shutting down gracefully
                 if getattr(agent, 'shutting_down', False):
@@ -2763,6 +2800,47 @@ class ResourceAgent(Agent):
                 else:
                     self.logger.info(f"Job reassignment disabled, not reassigning jobs from agent {agent_id}")
 
+    def _on_agent_recovered(self, agent_id: int, source: str) -> None:
+        """
+        Record the rejoin of a previously failed agent (ROADMAP item 14).
+
+        Called after the recovery tracker has removed the agent from
+        ``failed_agents``. The agent re-enters the neighbor/children map via
+        the normal refresh path (immediately for heartbeat-driven recovery,
+        on the next refresh cycle for channel-up/SWIM-driven recovery), which
+        also restores it to quorum accounting since quorum derives from the
+        live map.
+
+        :param agent_id: recovered agent
+        :param source: recovery evidence ("heartbeat", "channel-up", "swim")
+        """
+        now = time.time()
+        self._recovered_at.set(agent_id, now)
+        self.logger.info(
+            f"Agent {agent_id} RECOVERED (source: {source}) — rejoining pool. "
+            f"Live agents before re-add: {self.live_agent_count}/{self.configured_agent_count}"
+        )
+        self.metrics.agent_recoveries.append({
+            'agent_id': agent_id,
+            'recovered_at': now,
+            'source': source,
+        })
+        self.metrics.quorum_changes.append({
+            'timestamp': now,
+            'live_agents': self.live_agent_count,
+            'quorum': self.calculate_quorum(),
+            'reason': f'recovered_agent_{agent_id}'
+        })
+
+    def on_swim_member_alive(self, agent_id: int) -> None:
+        """SWIM saw the agent answer (alive/joined) — direct recovery evidence."""
+        if self.shutdown or not self.enable_agent_recovery:
+            return
+        if agent_id not in self.failed_agents:  # cheap guard: fires per SWIM ack
+            return
+        if self.recovery.recover_direct(agent_id):
+            self._on_agent_recovered(agent_id, source="swim")
+
     def _clear_consensus_for_failed_agent(self, failed_agent_id: int) -> None:
         """
         Clear consensus state for proposals involving a failed agent.
@@ -3119,16 +3197,8 @@ class ResourceAgent(Agent):
                 if agent_id is None:
                     agent_id = self._find_agent_by_endpoint(host, port)
 
-                if agent_id and agent_id in self.failed_agents:
-                    self.logger.info(
-                        f"Agent {agent_id} ({target}) recovered — removing from failed set. "
-                        f"Will rejoin on next neighbor refresh."
-                    )
-                    self.failed_agents.remove(agent_id)
-                    self.metrics.agent_recoveries.append({
-                        'agent_id': agent_id,
-                        'recovered_at': time.time(),
-                    })
+                if agent_id and self.recovery.recover_direct(agent_id):
+                    self._on_agent_recovered(agent_id, source="channel-up")
             except Exception as e:
                 self.logger.error(f"Failed to process peer recovery for {target}: {e}")
             return
@@ -3161,6 +3231,16 @@ class ResourceAgent(Agent):
 
             # Mark as failed immediately
             if failed_agent_id:
+                # Post-recovery settling window: the old channel may still
+                # report DOWN while its reconnect is in flight — don't flap
+                # a just-recovered agent back to failed on channel evidence.
+                recovered_at = self._recovered_at.get(failed_agent_id) or 0.0
+                if (time.time() - recovered_at) < self.recovery_cooldown_seconds:
+                    self.logger.info(
+                        f"Ignoring channel-DOWN for recently recovered agent {failed_agent_id} "
+                        f"(within {self.recovery_cooldown_seconds}s cooldown)"
+                    )
+                    return
                 if failed_agent_id not in self.failed_agents:
                     current_time = time.time()
                     self.failed_agents.set(failed_agent_id, current_time)

--- a/swarm/utils/recovery.py
+++ b/swarm/utils/recovery.py
@@ -1,0 +1,148 @@
+# MIT License
+#
+# Copyright (c) 2024 swarm-workflows
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# Author: Komal Thareja(kthare10@renci.org)
+"""
+Recovery state machine for failed agents (ROADMAP item 14).
+
+Failure detection marks an agent failed and removes it from the neighbor map;
+this module decides when a failed agent may rejoin. Two kinds of recovery
+evidence are distinguished:
+
+- **Passive (heartbeat freshness)**: the agent's Redis record is being updated
+  again. Because a single fresh timestamp can be a dying gasp or clock jitter,
+  promotion requires the record to stay fresh for a *grace window*
+  (``grace_seconds``). A stale observation inside the window resets it.
+- **Direct (we heard from it)**: a gRPC channel to the agent came back up, or
+  SWIM received an ack/alive for it. Direct evidence promotes immediately.
+
+The tracker manages only the recovery decision; the caller owns the side
+effects of rejoin (re-adding to neighbor maps, quorum accounting, metrics).
+"""
+
+import threading
+from typing import Dict, Optional
+
+
+class RecoveryTracker:
+    """Decides when agents in a failed set may rejoin.
+
+    The tracker shares the caller's *failed* mapping (agent_id ->
+    failure_timestamp): failure detection writes into it, and this class is
+    the only thing that removes entries from it.
+    """
+
+    def __init__(self, failed_agents, grace_seconds: float = 10.0):
+        """
+        :param failed_agents: mapping of agent_id -> failure timestamp; must
+            support ``__contains__``, ``remove(key)`` (ThreadSafeDict) or
+            ``__delitem__`` (plain dict).
+        :param grace_seconds: how long a failed agent's heartbeat must stay
+            fresh before passive promotion.
+        """
+        self._failed = failed_agents
+        self.grace_seconds = float(grace_seconds)
+        self._recovering: Dict[int, float] = {}  # agent_id -> first fresh ts
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # internals
+    # ------------------------------------------------------------------
+
+    def _remove_failed(self, agent_id: int) -> None:
+        remove = getattr(self._failed, "remove", None)
+        if callable(remove):
+            remove(agent_id)
+        else:
+            del self._failed[agent_id]
+
+    # ------------------------------------------------------------------
+    # observations
+    # ------------------------------------------------------------------
+
+    def observe(self, agent_id: int, last_updated: float, fresh: bool,
+                now: float) -> bool:
+        """Feed one heartbeat observation for a failed agent.
+
+        Recovery evidence is **progress**, not recency: the record must have
+        been written *after* the failure was declared (``last_updated`` past
+        the stored failure timestamp) and still be fresh. A dead agent's
+        lingering record is recent for up to the failure threshold after the
+        crash but never advances past the failure timestamp, so it can not
+        promote. (Assumes the usual same-cluster clock discipline; a live
+        agent heartbeats every tick, so modest skew only delays promotion.)
+
+        :param last_updated: the agent record's own update timestamp.
+        :param fresh: True when the record was updated within the failure
+            threshold.
+        :param now: current timestamp.
+        :return: True exactly once, when the agent is promoted (removed from
+            the failed set). False otherwise, including for agents that are
+            not failed.
+        """
+        with self._lock:
+            if agent_id not in self._failed:
+                self._recovering.pop(agent_id, None)
+                return False
+
+            failed_at = self._failed.get(agent_id) or 0.0
+            if not fresh or last_updated <= failed_at:
+                # No post-failure write yet (or gone stale again): reset.
+                self._recovering.pop(agent_id, None)
+                return False
+
+            first_fresh = self._recovering.get(agent_id)
+            if first_fresh is None:
+                self._recovering[agent_id] = now
+                return False
+
+            if (now - first_fresh) >= self.grace_seconds:
+                self._recovering.pop(agent_id, None)
+                self._remove_failed(agent_id)
+                return True
+            return False
+
+    def recover_direct(self, agent_id: int) -> bool:
+        """Promote immediately on direct evidence (channel up / SWIM ack).
+
+        :return: True if the agent was failed and is now recovered.
+        """
+        with self._lock:
+            if agent_id not in self._failed:
+                self._recovering.pop(agent_id, None)
+                return False
+            self._recovering.pop(agent_id, None)
+            self._remove_failed(agent_id)
+            return True
+
+    # ------------------------------------------------------------------
+    # introspection
+    # ------------------------------------------------------------------
+
+    def recovering_since(self, agent_id: int) -> Optional[float]:
+        """First-fresh timestamp for an agent inside its grace window."""
+        with self._lock:
+            return self._recovering.get(agent_id)
+
+    def recovering_count(self) -> int:
+        with self._lock:
+            return len(self._recovering)

--- a/tests/test_agent_recovery.py
+++ b/tests/test_agent_recovery.py
@@ -1,0 +1,160 @@
+# MIT License
+#
+# Copyright (c) 2024 swarm-workflows
+#
+# Author: Komal Thareja(kthare10@renci.org)
+"""Unit tests for the failed-agent recovery state machine (ROADMAP item 14)."""
+
+import threading
+
+import pytest
+
+from swarm.utils.recovery import RecoveryTracker
+from swarm.utils.thread_safe_dict import ThreadSafeDict
+
+
+GRACE = 10.0
+FAILED_AT = 100.0
+
+
+@pytest.fixture
+def failed():
+    return ThreadSafeDict()
+
+
+@pytest.fixture
+def tracker(failed):
+    return RecoveryTracker(failed, grace_seconds=GRACE)
+
+
+def fail_agent(failed, agent_id=7, ts=FAILED_AT):
+    failed.set(agent_id, ts)
+
+
+def obs(tracker, agent_id, last_updated, now, fresh=True):
+    return tracker.observe(agent_id, last_updated=last_updated, fresh=fresh, now=now)
+
+
+class TestPassiveRecovery:
+    """Heartbeat path: promotion needs post-failure progress + a grace window."""
+
+    def test_non_failed_agent_never_promotes(self, tracker):
+        assert obs(tracker, 1, last_updated=150.0, now=151.0) is False
+        assert obs(tracker, 1, last_updated=250.0, now=251.0) is False
+
+    def test_first_post_failure_heartbeat_starts_window_not_promotes(self, tracker, failed):
+        fail_agent(failed)
+        assert obs(tracker, 7, last_updated=200.0, now=201.0) is False
+        assert tracker.recovering_since(7) == 201.0
+        assert 7 in failed
+
+    def test_promotes_only_after_grace_elapsed(self, tracker, failed):
+        fail_agent(failed)
+        assert obs(tracker, 7, last_updated=200.0, now=200.0) is False
+        assert obs(tracker, 7, last_updated=209.0, now=200.0 + GRACE - 0.1) is False
+        assert obs(tracker, 7, last_updated=210.0, now=200.0 + GRACE) is True
+        assert 7 not in failed
+        assert tracker.recovering_since(7) is None
+
+    def test_pre_failure_heartbeat_never_promotes(self, tracker, failed):
+        """Regression: a dead agent's lingering record is 'fresh' for up to the
+        failure threshold after the crash, but its last_updated is frozen
+        before the failure timestamp — it must not start a recovery window.
+        (Observed live: SIGKILL at t, channel-down failure at t+5, spurious
+        heartbeat 'recovery' at t+11 before this check existed.)"""
+        fail_agent(failed, ts=FAILED_AT)
+        # Record frozen just before the failure was declared, still recent
+        stale_write = FAILED_AT - 4.0
+        assert obs(tracker, 7, last_updated=stale_write, now=FAILED_AT + 2) is False
+        assert tracker.recovering_since(7) is None
+        assert obs(tracker, 7, last_updated=stale_write, now=FAILED_AT + GRACE + 5) is False
+        assert 7 in failed
+
+    def test_promotion_happens_exactly_once(self, tracker, failed):
+        fail_agent(failed)
+        obs(tracker, 7, last_updated=200.0, now=200.0)
+        assert obs(tracker, 7, last_updated=211.0, now=200.0 + GRACE) is True
+        assert obs(tracker, 7, last_updated=300.0, now=301.0) is False
+
+    def test_stale_observation_resets_window(self, tracker, failed):
+        fail_agent(failed)
+        obs(tracker, 7, last_updated=200.0, now=200.0)
+        # Dying gasp: record stops advancing and goes stale
+        assert obs(tracker, 7, last_updated=200.0, now=205.0, fresh=False) is False
+        assert tracker.recovering_since(7) is None
+        # Fresh progress again: window restarts from scratch
+        assert obs(tracker, 7, last_updated=210.0, now=210.0) is False
+        assert obs(tracker, 7, last_updated=219.0, now=210.0 + GRACE - 0.1) is False
+        assert obs(tracker, 7, last_updated=220.0, now=210.0 + GRACE) is True
+
+
+class TestDirectRecovery:
+    """Channel-up / SWIM-ack path: immediate promotion."""
+
+    def test_direct_recovery_promotes_immediately(self, tracker, failed):
+        fail_agent(failed)
+        assert tracker.recover_direct(7) is True
+        assert 7 not in failed
+
+    def test_direct_recovery_for_healthy_agent_is_false(self, tracker):
+        assert tracker.recover_direct(3) is False
+
+    def test_direct_recovery_clears_pending_window(self, tracker, failed):
+        fail_agent(failed)
+        obs(tracker, 7, last_updated=200.0, now=200.0)
+        assert tracker.recover_direct(7) is True
+        assert tracker.recovering_since(7) is None
+        assert tracker.recovering_count() == 0
+
+    def test_direct_recovery_is_idempotent(self, tracker, failed):
+        fail_agent(failed)
+        assert tracker.recover_direct(7) is True
+        assert tracker.recover_direct(7) is False
+
+
+class TestFlapping:
+    """An agent that recovers and fails again goes through the full cycle."""
+
+    def test_refailure_after_recovery_requires_new_window(self, tracker, failed):
+        fail_agent(failed, ts=100.0)
+        obs(tracker, 7, last_updated=200.0, now=200.0)
+        assert obs(tracker, 7, last_updated=210.0, now=200.0 + GRACE) is True
+
+        # Fails again at t=300; heartbeats must now beat the NEW failure ts
+        fail_agent(failed, ts=300.0)
+        assert obs(tracker, 7, last_updated=250.0, now=305.0) is False  # pre-failure write
+        assert obs(tracker, 7, last_updated=306.0, now=306.0) is False  # window restarts
+        assert obs(tracker, 7, last_updated=316.0, now=306.0 + GRACE) is True
+
+
+class TestPlainDictCompat:
+    """Tracker works with a plain dict (no .remove method)."""
+
+    def test_plain_dict_backing(self):
+        failed = {7: FAILED_AT}
+        tracker = RecoveryTracker(failed, grace_seconds=GRACE)
+        assert tracker.recover_direct(7) is True
+        assert failed == {}
+
+
+class TestThreadSafety:
+    def test_concurrent_observations_promote_once(self, failed):
+        tracker = RecoveryTracker(failed, grace_seconds=0.0)  # promote on 2nd obs
+        fail_agent(failed)
+        obs(tracker, 7, last_updated=200.0, now=200.0)
+
+        promotions = []
+        barrier = threading.Barrier(8)
+
+        def worker():
+            barrier.wait()
+            if obs(tracker, 7, last_updated=210.0, now=210.0):
+                promotions.append(1)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert len(promotions) == 1
+        assert 7 not in failed


### PR DESCRIPTION
## Summary

Failed agents can now rejoin the pool through a proper recovery protocol instead of the previous channel-up-only partial path.

**`swarm/utils/recovery.py` — `RecoveryTracker`**: owns the rejoin decision for agents in the failed set (it is the only thing that removes entries from `failed_agents`). Two evidence classes:
- **Passive (heartbeat progress)** — the agent's record must be written *after* the failure timestamp and stay fresh for `recovery_grace_seconds` (default 10s). Recency alone is not evidence: a dead agent's record remains 'fresh' for up to the failure threshold after a crash — the first E2E run caught exactly this spurious recovery, now a regression test.
- **Direct (we heard from it)** — gRPC channel-up or SWIM alive/joined promotes immediately.

**Wiring in `resource_agent.py`**:
- `_refresh_agent_map` feeds heartbeat observations for failed agents and re-adds them on promotion (restores quorum automatically since quorum derives from the live map)
- `on_peer_status(up)` delegates to the tracker (replaces the old inline path)
- SWIM `on_agent_alive`/`on_agent_joined` now trigger recovery (previously advisory no-ops), with a cheap pre-check since alive fires per ack
- `_on_agent_recovered` centralizes side effects: `metrics.agent_recoveries` (now with `source`), `quorum_changes` entry
- **`recovery_cooldown_seconds`** (default 15s): after a rejoin, stale channel-DOWN events can't re-fail the agent while its reconnect settles — the second E2E run showed 3-4 such events per peer causing recover/re-fail flapping without it. Heartbeat-staleness detection is *not* suppressed, so a truly dead agent is still re-failed promptly.

**Config** (`config_swarm_multi.yml`): `recovery_grace_seconds`, `recovery_cooldown_seconds` alongside the existing `enable_agent_recovery`.

## Validation
- **Unit**: 13 tests in `tests/test_agent_recovery.py` — grace-window promotion, frozen-record regression, stale reset, direct-recovery idempotency, flap cycle, plain-dict compat, concurrent promote-once. Full suite: 159 passed.
- **End-to-end** (6-agent mesh, 174 Pegasus replay jobs, 15s failure threshold, 5s grace): SIGKILL agent 3 → peers detect in **1s** → **0 spurious recoveries** over a 30s dead window → restart → all 5 peers log exactly **one** `RECOVERED (source: heartbeat)` ~7s later, agent re-enters maps/registry, 3-4 stale DOWN events suppressed per peer.

ROADMAP item 14 marked done (remaining nuance noted: no state resync for pre-crash jobs — those are reassigned by the failure path).